### PR TITLE
Dashboard overhaul to integrate BC Assessment scraper

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from typing import Optional, Dict, List, Any
 
 from fastapi import FastAPI, Request, HTTPException
+from fastapi.staticfiles import StaticFiles
 from fastapi import Query
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
@@ -14,7 +15,17 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy import select, func
 
-from models import Base, RewListing, RewListingUrl, Sale, Assessment
+from models import (
+    Base,
+    RewListing,
+    RewListingUrl,
+    Sale,
+    Assessment,
+    Property,
+    PropertyCharacteristics,
+    RawScrape,
+    BCAssessmentUrl,
+)
 
 DATABASE_URL = os.getenv(
     "DATABASE_URL",
@@ -29,6 +40,8 @@ AsyncSessionLocal = sessionmaker(engine, expire_on_commit=False, class_=AsyncSes
 templates = Jinja2Templates(directory="templates")
 
 app = FastAPI(title="REW Listings Viewer")
+app.mount("/static", StaticFiles(directory="static"), name="static")
+
 
 def parse_int(value: Optional[str]) -> Optional[int]:
     """Convert a query string to int, or None if empty/invalid."""
@@ -171,66 +184,176 @@ async def on_startup():
 @app.get("/", response_class=HTMLResponse)
 async def home(request: Request):
     async with AsyncSessionLocal() as session:
-        total_stmt = select(func.count(RewListing.id))
-        total = (await session.execute(total_stmt)).scalar() or 0
+        # --- Global summary -------------------------------------------------
+        total_listings_stmt = select(func.count(RewListing.id))
+        total_listings = (await session.execute(total_listings_stmt)).scalar() or 0
 
+        total_properties = (
+            await session.execute(select(func.count(Property.id)))
+        ).scalar() or 0
+
+        total_sales = (
+            await session.execute(select(func.count(Sale.id)))
+        ).scalar() or 0
+
+        total_assessments = (
+            await session.execute(select(func.count(Assessment.id)))
+        ).scalar() or 0
+
+        total_property_chars = (
+            await session.execute(select(func.count(PropertyCharacteristics.id)))
+        ).scalar() or 0
+
+        total_raw_scrapes = (
+            await session.execute(select(func.count(RawScrape.id)))
+        ).scalar() or 0
+
+        # --- REW scraper panel ----------------------------------------------
         latest_stmt = (
             select(RewListing)
             .order_by(RewListing.scraped_at.desc())
             .limit(10)
         )
         latest = (await session.execute(latest_stmt)).scalars().all()
-        
-        #URL queue stats
-        total_urls_stmt = select(func.count(RewListingUrl.id))
-        total_urls = (await session.execute(total_urls_stmt)).scalar() or 0
 
-        done_urls_stmt = select(func.count(RewListingUrl.id)).where(
+        # URL queue stats for REW
+        total_rew_urls_stmt = select(func.count(RewListingUrl.id))
+        total_rew_urls = (
+            await session.execute(total_rew_urls_stmt)
+        ).scalar() or 0
+
+        rew_done_urls_stmt = select(func.count(RewListingUrl.id)).where(
             RewListingUrl.status == "done"
         )
-        done_urls = (await session.execute(done_urls_stmt)).scalar() or 0
+        rew_done_urls = (
+            await session.execute(rew_done_urls_stmt)
+        ).scalar() or 0
 
-        error_urls_stmt = select(func.count(RewListingUrl.id)).where(
+        rew_error_urls_stmt = select(func.count(RewListingUrl.id)).where(
             RewListingUrl.status == "error"
         )
-        error_urls = (await session.execute(error_urls_stmt)).scalar() or 0
+        rew_error_urls = (
+            await session.execute(rew_error_urls_stmt)
+        ).scalar() or 0
 
-        pending_urls = total_urls - done_urls - error_urls
-        scrape_ratio = (done_urls / total_urls) if total_urls > 0 else 0.0
+        rew_pending_urls = total_rew_urls - rew_done_urls - rew_error_urls
+        rew_scrape_ratio = (
+            rew_done_urls / total_rew_urls if total_rew_urls > 0 else 0.0
+        )
 
-        # Latest discovered URL (any status)
-        latest_discovered_stmt = (
+        # Latest discovered REW URL (any status)
+        latest_rew_discovered_stmt = (
             select(RewListingUrl)
             .order_by(RewListingUrl.discovered_at.desc())
             .limit(1)
         )
-        latest_discovered = (
-            await session.execute(latest_discovered_stmt)
+        latest_rew_discovered = (
+            await session.execute(latest_rew_discovered_stmt)
         ).scalars().first()
 
-        # Latest successfully scraped URL
-        latest_done_stmt = (
+        # Latest successfully scraped REW URL
+        latest_rew_done_stmt = (
             select(RewListingUrl)
             .where(RewListingUrl.status == "done")
             .order_by(RewListingUrl.last_attempt_at.desc().nullslast())
             .limit(1)
         )
-        latest_done = (await session.execute(latest_done_stmt)).scalars().first()
+        latest_rew_done = (
+            await session.execute(latest_rew_done_stmt)
+        ).scalars().first()
+
+        # --- BC Assessment scraper panel ------------------------------------
+        total_bca_urls_stmt = select(func.count(BCAssessmentUrl.id))
+        total_bca_urls = (
+            await session.execute(total_bca_urls_stmt)
+        ).scalar() or 0
+
+        bca_done_urls_stmt = select(func.count(BCAssessmentUrl.id)).where(
+            BCAssessmentUrl.status == "done"
+        )
+        bca_done_urls = (
+            await session.execute(bca_done_urls_stmt)
+        ).scalar() or 0
+
+        bca_error_urls_stmt = select(func.count(BCAssessmentUrl.id)).where(
+            BCAssessmentUrl.status == "error"
+        )
+        bca_error_urls = (
+            await session.execute(bca_error_urls_stmt)
+        ).scalar() or 0
+
+        bca_pending_urls = total_bca_urls - bca_done_urls - bca_error_urls
+        bca_scrape_ratio = (
+            bca_done_urls / total_bca_urls if total_bca_urls > 0 else 0.0
+        )
+
+        latest_bca_discovered_stmt = (
+            select(BCAssessmentUrl)
+            .order_by(BCAssessmentUrl.discovered_at.desc())
+            .limit(1)
+        )
+        latest_bca_discovered = (
+            await session.execute(latest_bca_discovered_stmt)
+        ).scalars().first()
+
+        latest_bca_done_stmt = (
+            select(BCAssessmentUrl)
+            .where(BCAssessmentUrl.status == "done")
+            .order_by(BCAssessmentUrl.last_attempt_at.desc().nullslast())
+            .limit(1)
+        )
+        latest_bca_done = (
+            await session.execute(latest_bca_done_stmt)
+        ).scalars().first()
+
+        # Latest BC Assessment properties (by characteristics)
+        latest_bca_props_stmt = (
+            select(PropertyCharacteristics, Property)
+            .join(Property, Property.id == PropertyCharacteristics.property_id)
+            .where(PropertyCharacteristics.source == "bc_assessment")
+            .order_by(PropertyCharacteristics.as_of_date.desc())
+            .limit(10)
+        )
+        latest_bca_props = (await session.execute(latest_bca_props_stmt)).all()
 
     return templates.TemplateResponse(
         "home.html",
         {
             "request": request,
-            "total": total,
+            # Global summary
+            "total_listings": total_listings,
+            "total_properties": total_properties,
+            "total_sales": total_sales,
+            "total_assessments": total_assessments,
+            "total_property_chars": total_property_chars,
+            "total_raw_scrapes": total_raw_scrapes,
+            "total_rew_urls": total_rew_urls,
+            "total_bca_urls": total_bca_urls,
+            # REW scraper stats
             "latest": latest,
-            # URL stats
-            "total_urls": total_urls,
-            "done_urls": done_urls,
-            "pending_urls": pending_urls,
-            "error_urls": error_urls,
-            "scrape_ratio": scrape_ratio,
-            "latest_discovered": latest_discovered,
-            "latest_done": latest_done,
+            "rew_done_urls": rew_done_urls,
+            "rew_pending_urls": rew_pending_urls,
+            "rew_error_urls": rew_error_urls,
+            "rew_scrape_ratio": rew_scrape_ratio,
+            "latest_rew_discovered": latest_rew_discovered,
+            "latest_rew_done": latest_rew_done,
+            # Backwards-compatible names (if anything else uses them)
+            "total": total_listings,
+            "total_urls": total_rew_urls,
+            "done_urls": rew_done_urls,
+            "pending_urls": rew_pending_urls,
+            "error_urls": rew_error_urls,
+            "scrape_ratio": rew_scrape_ratio,
+            "latest_discovered": latest_rew_discovered,
+            "latest_done": latest_rew_done,
+            # BC Assessment scraper stats
+            "bca_done_urls": bca_done_urls,
+            "bca_pending_urls": bca_pending_urls,
+            "bca_error_urls": bca_error_urls,
+            "bca_scrape_ratio": bca_scrape_ratio,
+            "latest_bca_discovered": latest_bca_discovered,
+            "latest_bca_done": latest_bca_done,
+            "latest_bca_props": latest_bca_props,
         },
     )
 

--- a/webapp/models.py
+++ b/webapp/models.py
@@ -1,4 +1,4 @@
-# webapp/models.py
+# scraper/models.py
 import os
 from datetime import datetime
 
@@ -26,11 +26,31 @@ DATABASE_URL = os.getenv(
 engine = create_async_engine(DATABASE_URL, echo=False, future=True)
 AsyncSessionLocal = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
 Base = declarative_base()
+
 class RewListingUrl(Base):
     __tablename__ = "rew_listing_urls"
 
     id = Column(Integer, primary_key=True)
     url = Column(Text, unique=True, nullable=False)
+    discovered_at = Column(DateTime(timezone=True), server_default=func.now())
+    status = Column(Text, nullable=False, server_default="pending")
+    last_attempt_at = Column(DateTime(timezone=True))
+    attempts = Column(Integer, nullable=False, server_default="0")
+    last_error = Column(Text)
+
+class BCAssessmentUrl(Base):
+    """
+    Queue of BC Assessment property pages to crawl.
+
+    We store fully qualified URLs like:
+      https://www.bcassessment.ca/Property/Info/QTAwMDAwMDFaTA==/
+    plus metadata for worker retries.
+    """
+    __tablename__ = "bc_assessment_urls"
+
+    id = Column(Integer, primary_key=True)
+    url = Column(Text, unique=True, nullable=False)
+    bc_property_id = Column(String(64))  # e.g. 'QTAwMDAwMDFaTA=='
     discovered_at = Column(DateTime(timezone=True), server_default=func.now())
     status = Column(Text, nullable=False, server_default="pending")
     last_attempt_at = Column(DateTime(timezone=True))
@@ -170,4 +190,3 @@ class RewListing(Base):
     __table_args__ = (
         UniqueConstraint("rew_url", name="uq_rew_url"),
     )
-

--- a/webapp/static/dashboard.css
+++ b/webapp/static/dashboard.css
@@ -1,0 +1,218 @@
+:root {
+  --bg: #f3f4f6;
+  --card-bg: #ffffff;
+  --border: #e5e7eb;
+  --accent: #2563eb;
+  --text-muted: #6b7280;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--bg);
+  color: #111827;
+}
+
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 24px 16px 40px;
+}
+
+h1 {
+  margin: 0 0 8px;
+  font-size: 1.8rem;
+}
+
+h2 {
+  margin: 0 0 8px;
+  font-size: 1.2rem;
+}
+
+h3 {
+  margin-top: 16px;
+  margin-bottom: 8px;
+  font-size: 1rem;
+}
+
+.page-subtitle {
+  margin: 0 0 24px;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+/* Global summary */
+
+.summary-section {
+  margin-bottom: 24px;
+}
+
+/* 2×4 grid: 4 cards per row on desktop */
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.card {
+  background: var(--card-bg);
+  border-radius: 12px;
+  padding: 10px 14px;
+  border: 1px solid var(--border);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+}
+
+.card-title {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  margin-bottom: 2px;
+}
+
+.card-value {
+  font-size: 1.3rem;
+  font-weight: 600;
+}
+
+.card-note {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+
+/* Panels */
+
+.panel {
+  background: var(--card-bg);
+  border-radius: 12px;
+  padding: 16px 18px 18px;
+  border: 1px solid var(--border);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  margin-bottom: 20px;
+}
+
+.panel-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.panel-subtitle {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+/* Small stats row */
+
+.stats-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 0.9rem;
+  margin-bottom: 10px;
+}
+
+.stats-list span strong {
+  font-weight: 600;
+}
+
+/* Utilities */
+
+.muted {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 0.8rem;
+  background: #f9fafb;
+  padding: 2px 4px;
+  border-radius: 4px;
+}
+
+/* Tables – shared style for dashboard + listings */
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 6px;
+  font-size: 0.9rem;
+}
+
+th,
+td {
+  padding: 6px 8px;
+  border-bottom: 1px solid #e5e7eb;
+  text-align: left;
+  vertical-align: top;
+}
+
+th {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  background: #f9fafb;
+}
+
+/* Actions / buttons */
+
+.actions {
+  margin-top: 8px;
+  margin-bottom: 4px;
+}
+
+.btn-link {
+  display: inline-block;
+  padding: 5px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--accent);
+  color: var(--accent);
+  text-decoration: none;
+  font-size: 0.85rem;
+  margin-right: 6px;
+}
+
+.btn-link:hover {
+  background: rgba(37, 99, 235, 0.06);
+}
+
+/* Responsive tweaks */
+
+@media (max-width: 900px) {
+  .summary-grid {
+    grid-template-columns: repeat(2, 1fr); /* 2×N on medium screens */
+  }
+}
+
+@media (max-width: 640px) {
+  .panel-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .stats-list {
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 900px) {
+    .summary-grid {
+    grid-template-columns: repeat(2, 1fr); /* 2×N grid on smaller screens */
+    }
+}
+
+@media (max-width: 500px) {
+  .summary-grid {
+    grid-template-columns: 1fr; /* Stack on very small screens */
+  }
+}

--- a/webapp/templates/home.html
+++ b/webapp/templates/home.html
@@ -1,96 +1,212 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>REW Listings - Dashboard</title>
+  <title>Real Estate Pipeline Dashboard</title>
+  <link rel="stylesheet" href="{{ url_for('static', path='dashboard.css') }}">
 </head>
 <body>
-  <h1>REW Listings - Dashboard</h1>
+  <div class="container">
+    <h1>Real Estate Pipeline Dashboard</h1>
 
-  <h2>Listings DB</h2>
-  <p>Total listings in DB: <strong>{{ total }}</strong></p>
+    <!-- Global Summary -->
+    <section class="summary-section">
+      <div class="summary-grid">
+        <div class="card">
+          <div class="card-title">Properties</div>
+          <div class="card-value">{{ total_properties }}</div>
+          <div class="card-note">Canonical property records</div>
+        </div>
+        <div class="card">
+          <div class="card-title">Listings</div>
+          <div class="card-value">{{ total_listings }}</div>
+          <div class="card-note">REW listings in DB</div>
+        </div>
+        <div class="card">
+          <div class="card-title">Sales</div>
+          <div class="card-value">{{ total_sales }}</div>
+          <div class="card-note">Recorded transactions</div>
+        </div>
+        <div class="card">
+          <div class="card-title">Assessments</div>
+          <div class="card-value">{{ total_assessments }}</div>
+          <div class="card-note">BC Assessment & other sources</div>
+        </div>
+        <div class="card">
+          <div class="card-title">Property Characteristics</div>
+          <div class="card-value">{{ total_property_chars }}</div>
+          <div class="card-note">Beds/baths/size snapshots</div>
+        </div>
+        <div class="card">
+          <div class="card-title">Raw Scrapes</div>
+          <div class="card-value">{{ total_raw_scrapes }}</div>
+          <div class="card-note">Raw HTML/JSON payloads</div>
+        </div>
+        <div class="card">
+          <div class="card-title">REW URLs</div>
+          <div class="card-value">{{ total_rew_urls }}</div>
+          <div class="card-note">Discovered listing URLs</div>
+        </div>
+        <div class="card">
+          <div class="card-title">BC Assessment URLs</div>
+          <div class="card-value">{{ total_bca_urls }}</div>
+          <div class="card-note">BC Assessment property pages</div>
+        </div>
+      </div>
+    </section>
 
-  <h2>URL Queue</h2>
-    <ul>
-    <li>Total URLs discovered: <strong>{{ total_urls }}</strong></li>
-    <li>Done (scraped): <strong>{{ done_urls }}</strong></li>
-    <li>Pending (incl. scraping): <strong>{{ pending_urls }}</strong></li>
-    <li>Errors: <strong>{{ error_urls }}</strong></li>
-    <li>
-        Scraped ratio:
-        <strong>
-        {% if total_urls > 0 %}
-            {{ '%.1f' % (scrape_ratio * 100) }}%
-        {% else %}
-            N/A
-        {% endif %}
-        </strong>
-    </li>
-    <li>
+    <!-- REW Scraper Panel -->
+    <section class="panel">
+      <div class="panel-header">
+        <h2>REW Scraper</h2>
+      </div>
+
+      <div class="stats-list">
+        <span>Total URLs discovered: <strong>{{ total_rew_urls }}</strong></span>
+        <span>Done: <strong>{{ rew_done_urls }}</strong></span>
+        <span>Pending: <strong>{{ rew_pending_urls }}</strong></span>
+        <span>Error: <strong>{{ rew_error_urls }}</strong></span>
+        <span>Scraped ratio:
+          <strong>
+            {% if rew_scrape_ratio %}
+              {{ "%.1f" % (rew_scrape_ratio * 100) }}%
+            {% else %}
+              0.0%
+            {% endif %}
+          </strong>
+        </span>
+      </div>
+
+      <p class="muted">
         Latest discovered URL:
-        {% if latest_discovered %}
-        <a href="{{ latest_discovered.url }}" target="_blank">
-            {{ latest_discovered.url }}
-        </a>
-        ({{ latest_discovered.discovered_at }})
+        {% if latest_rew_discovered %}
+          <code>{{ latest_rew_discovered.url }}</code>
         {% else %}
-        None yet
+          None yet
         {% endif %}
-    </li>
-    <li>
+        <br>
         Latest successfully scraped URL:
-        {% if latest_done %}
-        <a href="{{ latest_done.url }}" target="_blank">
-            {{ latest_done.url }}
+        {% if latest_rew_done %}
+          <code>{{ latest_rew_done.url }}</code>
+        {% else %}
+          None yet
+        {% endif %}
+      </p>
+
+      <h3>Latest scraped listings</h3>
+      <table>
+        <tr>
+          <th>Scraped At</th>
+          <th>Address</th>
+          <th>Neighbourhood</th>
+          <th>City</th>
+          <th>Price</th>
+          <th>Beds</th>
+          <th>Baths</th>
+          <th>Size (sqft)</th>
+        </tr>
+        {% for l in latest %}
+        <tr>
+          <td>{{ l.scraped_at }}</td>
+          <td>
+            <a href="{{ request.url_for('listing_detail', listing_id=l.id) }}">
+              {{ l.street_address or "(no address)" }}
+            </a>
+          </td>
+          <td>{{ l.neighbourhood }}</td>
+          <td>{{ l.city }}</td>
+          <td>
+            {% if l.price_cad %}
+              {{ '{:,}'.format(l.price_cad) }}
+            {% else %}
+              -
+            {% endif %}
+          </td>
+          <td>{{ l.beds }}</td>
+          <td>{{ l.baths }}</td>
+          <td>{{ l.sqft }}</td>
+        </tr>
+        {% endfor %}
+      </table>
+
+      <div class="actions">
+        <a href="{{ request.url_for('listings') }}" class="btn-link">
+          Browse listings (table)
         </a>
-        (last attempt: {{ latest_done.last_attempt_at }})
+        <a href="{{ request.url_for('map_view') }}" class="btn-link">
+          View listings on map
+        </a>
+      </div>
+
+    </section>
+
+    <!-- BC Assessment Scraper Panel -->
+    <section class="panel">
+      <div class="panel-header">
+        <h2>BC Assessment Scraper</h2>
+      </div>
+
+      <div class="stats-list">
+        <span>Total URLs discovered: <strong>{{ total_bca_urls }}</strong></span>
+        <span>Done: <strong>{{ bca_done_urls }}</strong></span>
+        <span>Pending: <strong>{{ bca_pending_urls }}</strong></span>
+        <span>Error: <strong>{{ bca_error_urls }}</strong></span>
+        <span>Scraped ratio:
+          <strong>
+            {% if bca_scrape_ratio %}
+              {{ "%.1f" % (bca_scrape_ratio * 100) }}%
+            {% else %}
+              0.0%
+            {% endif %}
+          </strong>
+        </span>
+      </div>
+
+      <p class="muted">
+        Latest discovered BC Assessment URL:
+        {% if latest_bca_discovered %}
+          <code>{{ latest_bca_discovered.url }}</code>
         {% else %}
-        None yet
+          None yet
         {% endif %}
-    </li>
-    </ul>
-
-
-  <h2>Latest scraped listings</h2>
-<table border="1" cellpadding="4">
-    <tr>
-      <th>Scraped At</th>
-      <th>Address</th>
-      <th>Neighbourhood</th>
-      <th>City</th>
-      <th>Price</th>
-      <th>Beds</th>
-      <th>Baths</th>
-      <th>Property Type</th>
-      <th>Size (sqft)</th>
-    </tr>
-    {% for l in latest %}
-    <tr>
-      <td>{{ l.scraped_at }}</td>
-      <td><a href="{{ request.url_for('listing_detail', listing_id=l.id) }}">
-          {{ l.street_address or "(no address)" }}
-        </a></td>
-      <td>{{ l.neighbourhood }}</td>
-      <td>{{ l.city }}</td>
-      <td>
-        {% if l.price_cad %}
-          {{ '{:,}'.format(l.price_cad) }}
+        <br>
+        Latest successfully scraped BC Assessment URL:
+        {% if latest_bca_done %}
+          <code>{{ latest_bca_done.url }}</code>
         {% else %}
-          -
+          None yet
         {% endif %}
-      </td>
-      <td>{{ l.beds }}</td>
-      <td>{{ l.baths }}</td>
-      <td>{{ l.property_type }}</td>
-      <td>{{ l.sqft }}</td>
-    </tr>
-    {% endfor %}
-  </table>
+      </p>
 
-<p>
-  <a href="{{ request.url_for('listings') }}">Browse listings (table)</a>
-  &nbsp;|&nbsp;
-  <a href="{{ request.url_for('map_view') }}">View listings on map</a>
-</p>
-
+      <h3>Latest BC Assessment properties</h3>
+      <table>
+        <tr>
+          <th>As of Date</th>
+          <th>Address</th>
+          <th>Beds</th>
+          <th>Baths</th>
+          <th>Building Sqft</th>
+          <th>Lot Sqft</th>
+          <th>Year Built</th>
+        </tr>
+        {% for char, prop in latest_bca_props %}
+        <tr>
+          <td>{{ char.as_of_date }}</td>
+          <td>
+            {% if prop %}
+              {{ prop.street_address }}, {{ prop.city }}
+            {% else %}
+              (no linked property)
+            {% endif %}
+          </td>
+          <td>{{ char.beds }}</td>
+          <td>{{ char.baths }}</td>
+          <td>{{ char.sqft }}</td>
+          <td>{{ char.lot_sqft }}</td>
+          <td>{{ char.year_built }}</td>
+        </tr>
+        {% endfor %}
+      </table>
+    </section>
+  </div>
 </body>
 </html>

--- a/webapp/templates/listings.html
+++ b/webapp/templates/listings.html
@@ -2,62 +2,78 @@
 <html>
 <head>
   <title>Browse Listings</title>
+  <link rel="stylesheet" href="{{ url_for('static', path='dashboard.css') }}">
 </head>
 <body>
-  <h1>Browse Listings</h1>
+  <div class="container">
+    <h1>Browse Listings</h1>
+    <p class="page-subtitle">
+      Paginated view of REW listings currently in the database.
+    </p>
 
-  <table border="1" cellpadding="4">
-    <tr>
-      <th>Price</th>
-      <th>Address</th>
-      <th>Neighbourhood</th>
-      <th>City</th>
-      <th>Beds</th>
-      <th>Baths</th>
-      <th>Property Type</th>
-      <th>Sqft</th>
-      <th>Scraped</th>
-    </tr>
-    {% for l in listings %}
-    <tr>
-      <td>
-        {% if l.price_cad %}
-          {{ '{:,}'.format(l.price_cad) }}
-        {% else %}
-          -
+    <section class="panel">
+      <div class="panel-header">
+        <h2>Listings</h2>
+        <div class="panel-subtitle">
+          Page {{ page }} of {{ total_pages }}
+        </div>
+      </div>
+
+      <table>
+        <tr>
+          <th>Price</th>
+          <th>Address</th>
+          <th>Neighbourhood</th>
+          <th>City</th>
+          <th>Beds</th>
+          <th>Baths</th>
+          <th>Property Type</th>
+          <th>Sqft</th>
+          <th>Scraped</th>
+        </tr>
+        {% for l in listings %}
+        <tr>
+          <td>
+            {% if l.price_cad %}
+              {{ '{:,}'.format(l.price_cad) }}
+            {% else %}
+              -
+            {% endif %}
+          </td>
+          <td>
+            <a href="{{ request.url_for('listing_detail', listing_id=l.id) }}">
+              {{ l.street_address or "(no address)" }}
+            </a>
+          </td>
+          <td>{{ l.neighbourhood }}</td>
+          <td>{{ l.city }}</td>
+          <td>{{ l.beds }}</td>
+          <td>{{ l.baths }}</td>
+          <td>{{ l.property_type }}</td>
+          <td>{{ l.sqft }}</td>
+          <td>{{ l.scraped_at }}</td>
+        </tr>
+        {% endfor %}
+      </table>
+
+      <div class="actions">
+        {% if page > 1 %}
+          <a href="{{ url_for('listings') }}?page={{ page - 1 }}" class="btn-link">Prev</a>
         {% endif %}
-      </td>
-      <td>
-        <a href="{{ request.url_for('listing_detail', listing_id=l.id) }}">
-          {{ l.street_address or "(no address)" }}
+        {% if page < total_pages %}
+          <a href="{{ url_for('listings') }}?page={{ page + 1 }}" class="btn-link">Next</a>
+        {% endif %}
+      </div>
+
+      <div class="actions">
+        <a href="{{ request.url_for('map_view') }}" class="btn-link">
+          View these listings on a map
         </a>
-      </td>
-      <td>{{ l.neighbourhood }}</td>
-      <td>{{ l.city }}</td>
-      <td>{{ l.beds }}</td>
-      <td>{{ l.baths }}</td>
-      <td>{{ l.property_type }}</td>
-      <td>{{ l.sqft }}</td>
-      <td>{{ l.scraped_at }}</td>
-    </tr>
-    {% endfor %}
-  </table>
-
-  <p>
-    Page {{ page }} / {{ total_pages }}
-    {% if page > 1 %}
-      <a href="/listings?page={{ page - 1 }}">Prev</a>
-    {% endif %}
-    {% if page < total_pages %}
-      <a href="/listings?page={{ page + 1 }}">Next</a>
-    {% endif %}
-  </p>
-
-  <p>
-    <a href="{{ request.url_for('map_view') }}">View these listings on a map</a>
-    &nbsp;|&nbsp;
-    <a href="{{ request.url_for('home') }}">Back to dashboard</a>
-  </p>
-
+        <a href="{{ request.url_for('home') }}" class="btn-link">
+          Back to dashboard
+        </a>
+      </div>
+    </section>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
Changes the frontend to report scraping stats on the bc assessment scraper. 
No longer a REW-focused dashboard, but reports on both the REW scraper and BC Assessment scraper, by adding URL stats for the BC Assessment, as well as the latest scraped properties. 

Implements some CSS for a fresh coat of paint using cards and a styling table.