### PR TITLE
Rew insights scraper

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,20 @@ services:
       DATABASE_URL: postgresql+asyncpg://rewuser:rewpass@db:5432/real_estate
       GEOCODER_URL: http://nominatim:8080/search
     command: ["python", "bc_assessment_worker.py"]
+  
+  rew_insights_scraper:
+    build:
+      context: ./scraper
+    container_name: rew_insights_scraper
+    init: true
+    shm_size: '2gb'
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql+asyncpg://rewuser:rewpass@db:5432/real_estate
+    command: ["python", "rew_insights_worker.py"]
+
 
   webapp:
     build:

--- a/scraper/models.py
+++ b/scraper/models.py
@@ -38,6 +38,25 @@ class RewListingUrl(Base):
     attempts = Column(Integer, nullable=False, server_default="0")
     last_error = Column(Text)
 
+class RewInsightsUrl(Base):
+    """
+    Queue of REW Insights URLs to crawl.
+
+    We store fully qualified URLs like:
+      https://www.rew.ca/insights/12345
+    plus metadata for worker retries.
+    """
+    __tablename__ = "rew_insights_urls"
+
+    id = Column(Integer, primary_key=True)
+    url = Column(Text, unique=True, nullable=False)
+
+    discovered_at = Column(DateTime(timezone=True), server_default=func.now())
+    status = Column(Text, nullable=False, server_default="pending")
+    last_attempt_at = Column(DateTime(timezone=True))
+    attempts = Column(Integer, nullable=False, server_default="0")
+    last_error = Column(Text)
+
 class BCAssessmentUrl(Base):
     """
     Queue of BC Assessment property pages to crawl.

--- a/scraper/parsers.py
+++ b/scraper/parsers.py
@@ -1,9 +1,10 @@
 # scraper/parsers.py
 import json
 import re
-from datetime import date
+from dataclasses import dataclass, asdict
+from datetime import date, datetime
 from typing import Any, Dict, Optional, List, Tuple
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse, unquote
 
 from bs4 import BeautifulSoup
 
@@ -461,3 +462,395 @@ def parse_bc_assessment_neighbor_urls(html_content: str, base_url: str = "https:
                 urls.add(urljoin(base_url, href))
 
     return sorted(urls)
+
+
+def _rew_insights_parse_number(text: Optional[str], *, float_ok: bool = False) -> Optional[float]:
+    """
+    Loose numeric parser for things like '3 beds', '1.5 baths', '1,234 sq ft'.
+    """
+    if not text:
+        return None
+    # remove commas to support 1,234.5
+    m = re.search(r"[\d\.]+", text.replace(",", ""))
+    if not m:
+        return None
+    val = float(m.group(0))
+    return val if float_ok else int(val)
+
+
+def _rew_insights_decode_polyline(encoded: str) -> List[tuple[float, float]]:
+    """
+    Minimal polyline decoder (Mapbox / Google style).
+    Returns a list of (lat, lng) tuples.
+    """
+    coords: List[tuple[float, float]] = []
+    index = 0
+    lat = 0
+    lng = 0
+    length = len(encoded)
+
+    while index < length:
+        result = 1
+        shift = 0
+        while True:
+            if index >= length:
+                break
+            b = ord(encoded[index]) - 63 - 1
+            index += 1
+            result += b << shift
+            shift += 5
+            if b < 0x1F:
+                break
+        delta_lat = ~(result >> 1) if (result & 1) else (result >> 1)
+        lat += delta_lat
+
+        result = 1
+        shift = 0
+        while True:
+            if index >= length:
+                break
+            b = ord(encoded[index]) - 63 - 1
+            index += 1
+            result += b << shift
+            shift += 5
+            if b < 0x1F:
+                break
+        delta_lng = ~(result >> 1) if (result & 1) else (result >> 1)
+        lng += delta_lng
+
+        coords.append((lat * 1e-5, lng * 1e-5))
+
+    return coords
+
+
+def _rew_insights_decode_mapbox_bbox_from_photo(url: Optional[str]) -> Optional[Dict[str, float]]:
+    """
+    Extract a rough building footprint bbox from the Mapbox static image URL
+    embedded in the JSON-LD 'photo.url' field.
+
+    Returns a dict compatible with geocoding.BBox.to_dict():
+        {'south': ..., 'north': ..., 'west': ..., 'east': ...}
+    """
+    if not url:
+        return None
+
+    # Mapbox static path segment looks like: path-1+...(...encoded_polyline...)/lon,lat,zoom/...
+    m = re.search(r"path-[^()]*\(([^)]+)\)", url)
+    if not m:
+        return None
+    encoded = unquote(m.group(1))
+    coords = _rew_insights_decode_polyline(encoded)
+    if not coords:
+        return None
+
+    lats = [lat for lat, _ in coords]
+    lngs = [lng for _, lng in coords]
+    return {
+        "south": min(lats),
+        "north": max(lats),
+        "west": min(lngs),
+        "east": max(lngs),
+    }
+
+
+@dataclass
+class RewInsightsBasicInfo:
+    as_of_date: Optional[date]
+    street_address: Optional[str]
+    city: Optional[str]
+    province: Optional[str]
+    postal_code: Optional[str]
+    lat: Optional[float]
+    lng: Optional[float]
+    bbox: Optional[Dict[str, float]]
+    property_type: Optional[str]
+    beds: Optional[float]
+    baths: Optional[float]
+    sqft: Optional[int]
+    year_built: Optional[int]
+    raw_place: Dict[str, Any]
+    raw_details: Dict[str, Any]
+
+
+def _parse_rew_insights_basic_info(soup: BeautifulSoup, page_url: str) -> RewInsightsBasicInfo:
+    """
+    Parse address, geo, basic stats + raw details from an Insights page.
+    """
+    place_data: Dict[str, Any] = {}
+
+    # 1) JSON-LD with @type = "Place"
+    for tag in soup.find_all("script", attrs={"type": "application/ld+json"}):
+        txt = tag.string or tag.text or ""
+        if not txt.strip():
+            continue
+        try:
+            data = json.loads(txt)
+        except Exception:
+            continue
+
+        # Some pages wrap this in a list, others as a single dict
+        if isinstance(data, list):
+            for item in data:
+                if isinstance(item, dict) and item.get("@type") == "Place":
+                    place_data = item
+                    break
+        elif isinstance(data, dict) and data.get("@type") == "Place":
+            place_data = data
+
+        if place_data:
+            break
+
+    addr = place_data.get("address") or {}
+    street_address = addr.get("streetAddress")
+    city = addr.get("addressLocality")
+    province = addr.get("addressRegion")
+    postal_code = addr.get("postalCode")
+
+    geo = place_data.get("geo") or {}
+    lat = float(geo["latitude"]) if geo.get("latitude") is not None else None
+    lng = float(geo["longitude"]) if geo.get("longitude") is not None else None
+
+    photo = place_data.get("photo") or {}
+    photo_url = photo.get("url")
+    bbox = _rew_insights_decode_mapbox_bbox_from_photo(photo_url)
+
+    # 2) Details panel (Type, Bedrooms, Size, Built, Bath, etc.)
+    details_container = soup.find("div", class_="insightsheader-details")
+    details: Dict[str, Any] = {}
+    as_of_date: Optional[date] = None
+
+    if details_container:
+        # <dl class="columnlist"><dt>Bedrooms</dt><dd>3</dd>...</dl>
+        for dl in details_container.select("dl.columnlist"):
+            dts = dl.find_all("dt")
+            dds = dl.find_all("dd")
+            for dt_tag, dd_tag in zip(dts, dds):
+                key = dt_tag.get_text(" ", strip=True).strip(":").lower()
+                val = dd_tag.get_text(" ", strip=True)
+                details[key] = val
+
+        # e.g. "Last updated at 2023-01-04"
+        updated_span = details_container.find(
+            "span", class_="insightsheader-updated_date"
+        )
+        if updated_span:
+            txt = updated_span.get_text(strip=True)
+            m = re.search(r"(\d{4}-\d{2}-\d{2})", txt)
+            if m:
+                try:
+                    as_of_date = datetime.strptime(m.group(1), "%Y-%m-%d").date()
+                except Exception:
+                    as_of_date = None
+
+    beds = _rew_insights_parse_number(details.get("bedrooms"), float_ok=True)
+    baths = _rew_insights_parse_number(details.get("bath"), float_ok=True)
+    sqft = _rew_insights_parse_number(details.get("size"), float_ok=False)
+
+    year_built = None
+    m = re.search(r"(\d{4})", details.get("built", "") or "")
+    if m:
+        year_built = int(m.group(1))
+
+    return RewInsightsBasicInfo(
+        as_of_date=as_of_date,
+        street_address=street_address,
+        city=city,
+        province=province,
+        postal_code=postal_code,
+        lat=lat,
+        lng=lng,
+        bbox=bbox,
+        property_type=details.get("type"),
+        beds=beds,
+        baths=baths,
+        sqft=sqft,
+        year_built=year_built,
+        raw_place=place_data,
+        raw_details=details,
+    )
+
+
+def parse_rew_insights_assessment_history(soup: BeautifulSoup) -> List[Dict[str, Any]]:
+    """
+    Parse the 'Assessment history' section into a list of dicts with:
+      - assessment_year
+      - total_assessed_cad
+      - land_value
+      - building_value
+      - raw.labels (the original label strings)
+    """
+    out: List[Dict[str, Any]] = []
+    section_title = soup.find(
+        "div",
+        class_="columnsection-title",
+        string=re.compile(r"Assessment history", re.I),
+    )
+    if not section_title:
+        return out
+
+    body = section_title.find_parent("div", class_="columnsection-body")
+    if not body:
+        return out
+
+    details = body.find("div", class_="detailslist")
+    if not details:
+        return out
+
+    for row in details.select("div.detailslist-row"):
+        labels = [lab.get_text(" ", strip=True) for lab in row.select("div.detailslist-label")]
+        if len(labels) < 2:
+            continue
+
+        total_txt = labels[0]
+        date_txt = labels[-1]
+
+        total_val = _parse_int(total_txt)
+        land_val: Optional[int] = None
+        building_val: Optional[int] = None
+
+        for lab in labels[1:-1]:
+            if lab.startswith("Land"):
+                land_val = _parse_int(lab)
+            elif lab.startswith("Building"):
+                building_val = _parse_int(lab)
+
+        year = None
+        m = re.search(r"(\d{4})", date_txt)
+        if m:
+            year = int(m.group(1))
+
+        out.append(
+            {
+                "assessment_year": year,
+                "total_assessed_cad": total_val,
+                "land_value": land_val,
+                "building_value": building_val,
+                "raw": {"labels": labels},
+            }
+        )
+
+    return out
+
+
+def parse_rew_insights_sales_history(soup: BeautifulSoup) -> List[Dict[str, Any]]:
+    """
+    Parse the 'Sales history' section into a list of dicts with:
+      - sale_date (string; normalized to date in worker)
+      - sale_price_cad
+      - raw.labels / raw.values
+    """
+    out: List[Dict[str, Any]] = []
+    section_title = soup.find(
+        "div",
+        class_="columnsection-title",
+        string=re.compile(r"Sales history", re.I),
+    )
+    if not section_title:
+        return out
+
+    body = section_title.find_parent("div", class_="columnsection-body")
+    if not body:
+        return out
+
+    details = body.find("div", class_="detailslist")
+    if not details:
+        return out
+
+    for row in details.select("div.detailslist-row"):
+        labels = [lab.get_text(" ", strip=True) for lab in row.select("div.detailslist-label")]
+        values = [val.get_text(" ", strip=True) for val in row.select("div.detailslist-value")]
+
+        if not labels:
+            continue
+
+        price_txt = labels[0]
+        date_txt = labels[2] if len(labels) > 2 else None  # 'Sold' usually in labels[1]
+
+        price_val = _parse_int(price_txt)
+
+        out.append(
+            {
+                "sale_date": date_txt,
+                "sale_price_cad": price_val,
+                "raw": {
+                    "labels": labels,
+                    "values": values,
+                },
+            }
+        )
+
+    return out
+
+
+def parse_rew_insights_neighbourhood_links(
+    soup: BeautifulSoup,
+    page_url: str,
+    base_url: str = "https://www.rew.ca",
+) -> Dict[str, List[str]]:
+    """
+    Collect nearby Insights and listings from card carousels.
+
+    Categorize:
+      - /insights/...   -> insights_urls
+      - /properties/... -> listing_urls
+    """
+    insights: set[str] = set()
+    listings: set[str] = set()
+    others: set[str] = set()
+
+    parsed_page = urlparse(page_url)
+    canonical_path = parsed_page.path
+
+    for a in soup.select("a.previewcard-link, a.verticalcard-link"):
+        href = a.get("href")
+        if not href:
+            continue
+
+        full = urljoin(base_url, href)
+        if urlparse(full).path == canonical_path:
+            # skip self-link if any
+            continue
+
+        if "/insights/" in href:
+            insights.add(full)
+        elif "/properties/" in href:
+            listings.add(full)
+        else:
+            others.add(full)
+
+    return {
+        "insights_urls": sorted(insights),
+        "listing_urls": sorted(listings),
+        "other_urls": sorted(others),
+    }
+
+
+def parse_rew_insights(html: str, url: str) -> Dict[str, Any]:
+    """
+    High-level REW Insights parser that returns:
+      {
+        "url": url,
+        "basic": { ... },
+        "assessments": [...],
+        "sales": [...],
+        "neighbourhood_links": {
+            "insights_urls": [...],
+            "listing_urls": [...],
+            "other_urls": [...]
+        },
+      }
+    """
+    soup = BeautifulSoup(html, "html.parser")
+
+    basic_obj = _parse_rew_insights_basic_info(soup, url)
+    assessments = parse_rew_insights_assessment_history(soup)
+    sales = parse_rew_insights_sales_history(soup)
+    neighbourhood_links = parse_rew_insights_neighbourhood_links(soup, url)
+
+    return {
+        "url": url,
+        "basic": asdict(basic_obj),
+        "assessments": assessments,
+        "sales": sales,
+        "neighbourhood_links": neighbourhood_links,
+    }

--- a/scraper/rew_insights_url_queue.py
+++ b/scraper/rew_insights_url_queue.py
@@ -1,0 +1,100 @@
+# scraper/rew_insights_url_queue.py
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from models import RewInsightsUrl
+
+MAX_SCRAPE_ATTEMPTS = 5
+
+
+async def enqueue_insights_urls(urls: list[str], session: AsyncSession) -> int:
+    """
+    Insert new REW Insights URLs into rew_insights_urls, ignoring duplicates.
+    """
+    if not urls:
+        return 0
+
+    rows = [{"url": u} for u in urls]
+
+    stmt = pg_insert(RewInsightsUrl).values(rows)
+    stmt = stmt.on_conflict_do_nothing(index_elements=[RewInsightsUrl.url])
+
+    result = await session.execute(stmt)
+    await session.commit()
+    return result.rowcount or 0
+
+
+async def dequeue_next_batch(session: AsyncSession, batch_size: int = 5):
+    """
+    Fetch and lock the next batch of Insights URLs to scrape.
+    Mirrored from rew_listing_urls / bc_assessment_urls.
+    """
+    stmt = text(
+        """
+        WITH picked AS (
+            SELECT id, url
+            FROM rew_insights_urls
+            WHERE
+                (
+                    status = 'pending'
+                    OR (status = 'error' AND attempts < :max_attempts)
+                )
+            ORDER BY discovered_at
+            LIMIT :batch_size
+            FOR UPDATE SKIP LOCKED
+        )
+        UPDATE rew_insights_urls
+        SET status='scraping',
+            attempts = attempts + 1,
+            last_attempt_at = NOW()
+        WHERE id IN (SELECT id FROM picked)
+        RETURNING id, url;
+        """
+    )
+
+    rows = (
+        await session.execute(
+            stmt,
+            {"batch_size": batch_size, "max_attempts": MAX_SCRAPE_ATTEMPTS},
+        )
+    ).fetchall()
+    await session.commit()
+    return rows
+
+
+async def mark_done(session: AsyncSession, row_id: int):
+    await session.execute(
+        text(
+            """
+            UPDATE rew_insights_urls
+            SET status='done'
+            WHERE id=:id
+            """
+        ),
+        {"id": row_id},
+    )
+    await session.commit()
+
+
+async def mark_failed(session: AsyncSession, row_id: int, error_msg: str):
+    await session.execute(
+        text(
+            """
+            UPDATE rew_insights_urls
+            SET 
+                status = CASE
+                    WHEN attempts >= :max_attempts THEN 'dead'
+                    ELSE 'error'
+                END,
+                last_error = :err
+            WHERE id = :id
+            """
+        ),
+        {
+            "id": row_id,
+            "err": error_msg,
+            "max_attempts": MAX_SCRAPE_ATTEMPTS,
+        },
+    )
+    await session.commit()

--- a/scraper/rew_insights_worker.py
+++ b/scraper/rew_insights_worker.py
@@ -292,14 +292,19 @@ async def main():
     browser_conf = BrowserConfig(
         headless=True,
         enable_stealth=True,
+        user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
         verbose=False,
         extra_args=[
             "--no-sandbox",
             "--disable-dev-shm-usage",
             "--disable-gpu",
         ],
-        adapter=UndetectedAdapter(),
-        crawler_strategy=AsyncPlaywrightCrawlerStrategy,
+    )
+
+    adapter = UndetectedAdapter()
+    strategy = AsyncPlaywrightCrawlerStrategy(
+        browser_config=browser_conf,
+        browser_adapter=adapter
     )
 
     batch_counter = 0
@@ -307,7 +312,7 @@ async def main():
     while True:
         try:
             logger.info("Creating AsyncWebCrawler for REW Insights...")
-            async with AsyncWebCrawler(config=browser_conf) as crawler:
+            async with AsyncWebCrawler(config=browser_conf, crawler_strategy=strategy) as crawler:
                 logger.info("Crawler ready, entering main loop")
                 consecutive_timeout_batches = 0
 

--- a/scraper/rew_insights_worker.py
+++ b/scraper/rew_insights_worker.py
@@ -1,0 +1,355 @@
+# scraper/rew_insights_worker.py
+import asyncio
+import random
+import logging
+import pathlib
+from datetime import datetime, date
+
+from logging_config import setup_logging
+
+from crawl4ai import (
+    AsyncWebCrawler,
+    BrowserConfig,
+    CrawlerRunConfig,
+    CacheMode,
+    UndetectedAdapter,
+)
+from crawl4ai.async_crawler_strategy import AsyncPlaywrightCrawlerStrategy
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from models import (
+    AsyncSessionLocal,
+    init_db,
+    PropertyCharacteristics,
+    Assessment,
+    Sale,
+    RawScrape,
+)
+from geocoding import BBox
+from property_utils import get_or_create_property
+from parsers import parse_rew_insights
+from rew_insights_url_queue import (
+    dequeue_next_batch,
+    mark_done,
+    mark_failed,
+    enqueue_insights_urls,
+)
+from url_queue import enqueue_urls  # existing REW listing URL queue
+
+logger = logging.getLogger(f"scraper.{pathlib.Path(__file__).stem}")
+setup_logging()
+
+EMPTY_QUEUE_SLEEP_SECONDS = 60
+PER_URL_SLEEP_SECONDS = 1
+PAGE_LOAD_TIMEOUT_SECONDS = 30  # seconds (we pass ms to crawl4ai)
+BATCH_SIZE = 5
+RESTART_BROWSER_EVERY_N_BATCHES = 5
+
+# Timeout / Backoff Tuning for 'flaky' timeouts
+MAX_RETRIES_ON_TIMEOUT = 3
+TIMEOUT_BACKOFF_SECONDS = [5 * 60, 15 * 60, 45 * 60]
+
+
+def _json_safe(value):
+    """
+    Recursively convert any date/datetime objects to ISO strings so they can
+    be stored in a JSON/JSONB column.
+    """
+    if isinstance(value, (date, datetime)):
+        return value.isoformat()
+    if isinstance(value, dict):
+        return {k: _json_safe(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_json_safe(v) for v in value]
+    return value
+
+
+async def upsert_property_characteristics_rew_insights(session, prop_id: int, basic: dict):
+    """
+    Insert a PropertyCharacteristics snapshot from REW Insights.
+    """
+    as_of_date = basic.get("as_of_date") or datetime.utcnow().date()
+
+    row = {
+        "property_id": prop_id,
+        "as_of_date": as_of_date,
+        "source": "rew_insights",
+        "beds": basic.get("beds"),
+        "baths": basic.get("baths"),
+        "sqft_finished": basic.get("sqft"),
+        "sqft_unfinished": None,
+        "lot_sqft": None,
+        "year_built": basic.get("year_built"),
+        "raw_blob": _json_safe(basic),
+        "scraped_at": datetime.utcnow(),
+    }
+
+    stmt = pg_insert(PropertyCharacteristics).values(row)
+    stmt = stmt.on_conflict_do_nothing(
+        index_elements=["property_id", "as_of_date", "source"]
+    )
+    await session.execute(stmt)
+
+
+async def upsert_assessments_rew_insights(session, prop_id: int, assessments: list[dict]):
+    if not assessments:
+        return
+
+    rows = []
+    for a in assessments:
+        year = a.get("assessment_year")
+        total = a.get("total_assessed_cad")
+        if not year or total is None:
+            continue
+
+        rows.append(
+            {
+                "property_id": prop_id,
+                "assessment_year": year,
+                "total_assessed_cad": total,
+                "land_value": a.get("land_value"),
+                "building_value": a.get("building_value"),
+                "source": "rew_insights",
+                "raw_blob": _json_safe(a),
+            }
+        )
+
+    if not rows:
+        return
+
+    stmt = pg_insert(Assessment).values(rows)
+    stmt = stmt.on_conflict_do_nothing(
+        index_elements=["property_id", "assessment_year", "source"]
+    )
+    await session.execute(stmt)
+
+
+def _parse_rew_insights_sale_date(raw: str | None) -> date | None:
+    if not raw:
+        return None
+
+    raw = raw.strip()
+    # Try a few likely formats
+    for fmt in ("%b %d, %Y", "%Y-%m-%d", "%d %b %Y"):
+        try:
+            return datetime.strptime(raw, fmt).date()
+        except Exception:
+            continue
+    # As a last resort, just ignore if we can't parse confidently
+    logger.debug(f"Could not parse REW Insights sale date: {raw!r}")
+    return None
+
+
+async def upsert_sales_rew_insights(session, prop_id: int, sales: list[dict]):
+    if not sales:
+        return
+
+    rows = []
+    for s in sales:
+        price = s.get("sale_price_cad")
+        if price is None:
+            continue
+        d = _parse_rew_insights_sale_date(s.get("sale_date"))
+        if not d:
+            continue
+
+        rows.append(
+            {
+                "property_id": prop_id,
+                "sale_date": d,
+                "sale_price_cad": price,
+                "list_price_cad": None,
+                "mls_number": None,
+                "source": "rew_insights",
+                "beds": None,
+                "baths": None,
+                "sqft": None,
+                "lot_sqft": None,
+                "raw_blob": _json_safe(s.get("raw", {})),
+            }
+        )
+
+    if not rows:
+        return
+
+    stmt = pg_insert(Sale).values(rows)
+    stmt = stmt.on_conflict_do_nothing(
+        index_elements=["property_id", "sale_date", "sale_price_cad", "source"]
+    )
+    await session.execute(stmt)
+
+
+async def scrape_rew_insights_page(crawler: AsyncWebCrawler, session, url: str) -> None:
+    """
+    Visit a REW Insights page, parse:
+      * canonical address -> Property
+      * characteristics -> PropertyCharacteristics(source='rew_insights')
+      * assessments -> Assessment(source='rew_insights')
+      * sales -> Sale(source='rew_insights')
+      * neighbour URLs -> enqueue into RewInsightsUrl + RewListingUrl
+    """
+    logger.info(f"Scraping REW Insights: {url}")
+
+    run_conf = CrawlerRunConfig(
+        cache_mode=CacheMode.BYPASS,
+        wait_for="css:.insightsheader-details",
+        wait_until="domcontentloaded",
+        page_timeout=PAGE_LOAD_TIMEOUT_SECONDS * 1000,
+        delay_before_return_html=1.5,
+        magic=True,
+    )
+
+    result = await crawler.arun(url=url, config=run_conf)
+
+    if not getattr(result, "success", True):
+        raise RuntimeError(f"Crawl failed for {url}: {getattr(result, 'error_message', 'unknown')}")
+
+    html = getattr(result, "html", None) or getattr(result, "content", None)
+    if not html:
+        logger.warning(f"No HTML returned for {url}")
+        return
+
+    # Store raw HTML snapshot
+    rs = RawScrape(
+        source="rew_insights",
+        url=url,
+        http_status=200,
+        payload_type="html",
+        payload=html,
+    )
+    session.add(rs)
+
+    parsed = parse_rew_insights(html, url)
+    basic = parsed.get("basic") or {}
+
+    street = basic.get("street_address")
+    city = basic.get("city")
+    province = basic.get("province") or "BC"
+    postal = basic.get("postal_code")
+
+    if not street or not city:
+        logger.warning(f"Could not parse main address from Insights page {url}")
+        await session.commit()  # at least keep RawScrape
+        return
+
+    bbox_dict = basic.get("bbox")
+    bbox_obj = BBox(
+        south=bbox_dict["south"],
+        north=bbox_dict["north"],
+        west=bbox_dict["west"],
+        east=bbox_dict["east"],
+    ) if bbox_dict else None
+
+    # Map Insights address -> Property
+    prop = await get_or_create_property(
+        session=session,
+        street=street,
+        city=city,
+        province=province,
+        postal_code=postal,
+        lat=basic.get("lat"),
+        lng=basic.get("lng"),
+        bbox=bbox_obj,
+    )
+    prop_id = prop.id
+
+    # Characteristics snapshot
+    await upsert_property_characteristics_rew_insights(session, prop_id, basic)
+
+    # Assessments
+    assessments = parsed.get("assessments") or []
+    await upsert_assessments_rew_insights(session, prop_id, assessments)
+
+    # Sales history
+    sales = parsed.get("sales") or []
+    await upsert_sales_rew_insights(session, prop_id, sales)
+
+    # Neighbourhood links
+    links = parsed.get("neighbourhood_links") or {}
+    insights_urls = links.get("insights_urls") or []
+    listing_urls = links.get("listing_urls") or []
+
+    if insights_urls:
+        inserted_insights = await enqueue_insights_urls(insights_urls, session)
+        logger.info(f"  -> enqueued {inserted_insights} neighbouring REW Insights URLs")
+
+    if listing_urls:
+        inserted_listings = await enqueue_urls(listing_urls, session)
+        logger.info(f"  -> enqueued {inserted_listings} neighbouring REW listing URLs")
+
+    await session.commit()
+    logger.info(
+        f"Finished REW Insights scrape for property_id={prop_id} "
+        f"({street}, {city}, {province} {postal or ''})"
+    )
+
+
+async def main():
+    await init_db()
+    logger.info("DB init complete for REW Insights worker")
+
+    # Configure browser
+    browser_conf = BrowserConfig(
+        headless=True,
+        enable_stealth=True,
+        verbose=False,
+        extra_args=[
+            "--no-sandbox",
+            "--disable-dev-shm-usage",
+            "--disable-gpu",
+        ],
+        adapter=UndetectedAdapter(),
+        crawler_strategy=AsyncPlaywrightCrawlerStrategy,
+    )
+
+    batch_counter = 0
+
+    while True:
+        try:
+            logger.info("Creating AsyncWebCrawler for REW Insights...")
+            async with AsyncWebCrawler(config=browser_conf) as crawler:
+                logger.info("Crawler ready, entering main loop")
+                consecutive_timeout_batches = 0
+
+                while True:
+                    batch_counter += 1
+
+                    async with AsyncSessionLocal() as session:
+                        logger.info(f"Starting new Insights batch (#{batch_counter})...")
+                        batch = await dequeue_next_batch(session, batch_size=BATCH_SIZE)
+
+                        if not batch:
+                            logger.info(
+                                f"No pending REW Insights URLs. "
+                                f"Sleeping for {EMPTY_QUEUE_SLEEP_SECONDS} seconds..."
+                            )
+                            await asyncio.sleep(EMPTY_QUEUE_SLEEP_SECONDS)
+                            continue
+
+                        for url_id, url in batch:
+                            try:
+                                await scrape_rew_insights_page(crawler, session, url)
+                                await mark_done(session, url_id)
+                            except Exception as e:
+                                await mark_failed(session, url_id, str(e))
+                                logger.exception(f"Failed Insights scrape: {url} ({e})")
+
+                            sleep_for = PER_URL_SLEEP_SECONDS + random.uniform(0, 1)
+                            logger.info(f"Sleeping {sleep_for:.2f}s before next Insights URL...")
+                            await asyncio.sleep(sleep_for)
+
+                    # Periodically recycle the browser to avoid Playwright weirdness
+                    if batch_counter % RESTART_BROWSER_EVERY_N_BATCHES == 0:
+                        logger.info("Recycling browser instance for REW Insights...")
+                        break
+
+        except Exception as e:
+            logger.critical(
+                f"REW Insights crawler crashed completely: {e}. "
+                "Restarting loop in 10s..."
+            )
+            await asyncio.sleep(10)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scraper/seed_rew_insights_from_properties.py
+++ b/scraper/seed_rew_insights_from_properties.py
@@ -1,0 +1,459 @@
+# scraper/seed_rew_insights_from_properties.py
+#
+# Seed REW Insights data starting from the Properties table.
+#
+# For each Property:
+#   - build a formatted address string
+#   - call https://www.rew.ca/insights/autocomplete?term=<address>
+#   - pick the first suggestion that looks like an Insights URL
+#   - fetch that Insights page (plain requests)
+#   - parse via parsers.parse_rew_insights(html, url)
+#   - upsert:
+#       * PropertyCharacteristics(source='rew_insights')
+#       * Assessment(source='rew_insights')
+#       * Sale(source='rew_insights')
+#   - optionally enqueue neighbour Insights/listing URLs
+#
+# This is analogous in spirit to seed_bc_assessments_from_rew_listings.py,
+# but uses REW's autocomplete HTTP endpoint instead of simulating a browser.
+
+import asyncio
+import logging
+import pathlib
+import random
+
+from datetime import datetime, date
+from typing import Any, Dict, List, Optional
+from urllib.parse import urljoin
+
+import requests
+from sqlalchemy import select, exists, and_
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from logging_config import setup_logging
+
+from models import (
+    AsyncSessionLocal,
+    init_db,
+    Property,
+    PropertyCharacteristics,
+    Assessment,
+    Sale,
+)
+from property_utils import format_full_address
+from parsers import parse_rew_insights
+
+from rew_insights_url_queue import enqueue_insights_urls
+from url_queue import enqueue_urls
+
+
+logger = logging.getLogger(f"scraper.{pathlib.Path(__file__).stem}")
+setup_logging()
+
+BASE_URL = "https://www.rew.ca"
+INSIGHTS_AUTOCOMPLETE_PATH = "/insights/autocomplete"
+
+# Tunables
+BATCH_SIZE = 5
+EMPTY_SLEEP_SECONDS = 60
+PER_PROPERTY_SLEEP_SECONDS = 1
+
+
+# ---------------------------------------------------------------------------
+# Helpers for JSON / date handling
+# ---------------------------------------------------------------------------
+
+def _json_safe(value):
+    """
+    Recursively convert any date/datetime objects to ISO strings so they can
+    be safely stored in a JSON/JSONB column.
+    """
+    if isinstance(value, (date, datetime)):
+        return value.isoformat()
+    if isinstance(value, dict):
+        return {k: _json_safe(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_json_safe(v) for v in value]
+    return value
+
+
+def _parse_rew_insights_sale_date(raw: Optional[str]) -> Optional[date]:
+    if not raw:
+        return None
+
+    raw = raw.strip()
+    for fmt in ("%b %d, %Y", "%Y-%m-%d", "%d %b %Y"):
+        try:
+            return datetime.strptime(raw, fmt).date()
+        except Exception:
+            continue
+
+    logger.debug(f"Could not parse REW Insights sale date: {raw!r}")
+    return None
+
+
+# ---------------------------------------------------------------------------
+# HTTP autocomplete -> Insights URL
+# ---------------------------------------------------------------------------
+
+def lookup_insights_url_via_autocomplete(address: str) -> Optional[str]:
+    """
+    Call the same autocomplete endpoint the REW Insights search uses and
+    return the first Insights URL, or None if nothing matches.
+
+    This is synchronous and uses requests; we call it from async code in a
+    sequential fashion, which is acceptable for a seeder.
+    """
+    url = urljoin(BASE_URL, INSIGHTS_AUTOCOMPLETE_PATH)
+
+    headers = {
+        "User-Agent": "Mozilla/5.0 (rew-insights-seeder)",
+        "Accept": "application/json, text/javascript, */*; q=0.01",
+        "Referer": urljoin(BASE_URL, "/insights"),
+    }
+
+    params = {"term": address}
+
+    resp = requests.get(url, params=params, headers=headers, timeout=15)
+    resp.raise_for_status()
+
+    try:
+        data = resp.json()
+    except Exception as e:
+        logger.warning(f"Autocomplete JSON decode failed for address {address!r}: {e}")
+        return None
+
+    candidates: List[Dict[str, Any]] = []
+
+    if isinstance(data, list):
+        candidates = data
+    elif isinstance(data, dict):
+        # common patterns: {'results': [...]}, {'suggestions': [...]}, etc.
+        for key in ("results", "suggestions", "items"):
+            if isinstance(data.get(key), list):
+                candidates = data[key]
+                break
+
+    for item in candidates:
+        if not isinstance(item, dict):
+            continue
+
+        # Try common fields
+        for field in ("url", "href", "link", "value"):
+            val = item.get(field)
+            if isinstance(val, str) and "/insights/" in val:
+                return urljoin(BASE_URL, val)
+
+        # Fallback: scan values for any string containing '/insights/'
+        for v in item.values():
+            if isinstance(v, str) and "/insights/" in v:
+                return urljoin(BASE_URL, v)
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# DB upsert helpers for REW Insights
+# ---------------------------------------------------------------------------
+
+async def upsert_property_characteristics_rew_insights(
+    session,
+    property_id: int,
+    basic: Dict[str, Any],
+):
+    as_of_raw = basic.get("as_of_date")
+    if isinstance(as_of_raw, str):
+        # leave as string; schema probably stores date, but we'll let the DB
+        # cast or fallback to today if empty
+        try:
+            as_of_date = datetime.fromisoformat(as_of_raw).date()
+        except Exception:
+            as_of_date = datetime.utcnow().date()
+    elif isinstance(as_of_raw, date):
+        as_of_date = as_of_raw
+    else:
+        as_of_date = datetime.utcnow().date()
+
+    row = {
+        "property_id": property_id,
+        "as_of_date": as_of_date,
+        "source": "rew_insights",
+        "beds": basic.get("beds"),
+        "baths": basic.get("baths"),
+        "sqft_finished": basic.get("sqft"),
+        "sqft_unfinished": None,
+        "lot_sqft": None,
+        "year_built": basic.get("year_built"),
+        "raw_blob": _json_safe(basic),
+        "scraped_at": datetime.utcnow(),
+    }
+
+    stmt = pg_insert(PropertyCharacteristics).values(row)
+    stmt = stmt.on_conflict_do_nothing(
+        index_elements=["property_id", "as_of_date", "source"]
+    )
+    await session.execute(stmt)
+
+
+async def upsert_assessments_rew_insights(
+    session,
+    property_id: int,
+    assessments: List[Dict[str, Any]],
+):
+    if not assessments:
+        return
+
+    rows = []
+    for a in assessments:
+        year = a.get("assessment_year")
+        total = a.get("total_assessed_cad")
+        if not year or total is None:
+            continue
+
+        rows.append(
+            {
+                "property_id": property_id,
+                "assessment_year": year,
+                "total_assessed_cad": total,
+                "land_value": a.get("land_value"),
+                "building_value": a.get("building_value"),
+                "source": "rew_insights",
+                "raw_blob": _json_safe(a),
+            }
+        )
+
+    if not rows:
+        return
+
+    stmt = pg_insert(Assessment).values(rows)
+    stmt = stmt.on_conflict_do_nothing(
+        index_elements=["property_id", "assessment_year", "source"]
+    )
+    await session.execute(stmt)
+
+
+async def upsert_sales_rew_insights(
+    session,
+    property_id: int,
+    sales: List[Dict[str, Any]],
+):
+    if not sales:
+        return
+
+    rows = []
+    for s in sales:
+        price = s.get("sale_price_cad")
+        if price is None:
+            continue
+        d = _parse_rew_insights_sale_date(s.get("sale_date"))
+        if not d:
+            continue
+
+        rows.append(
+            {
+                "property_id": property_id,
+                "sale_date": d,
+                "sale_price_cad": price,
+                "list_price_cad": None,
+                "mls_number": None,
+                "source": "rew_insights",
+                "beds": None,
+                "baths": None,
+                "sqft": None,
+                "lot_sqft": None,
+                "raw_blob": _json_safe(s.get("raw", {})),
+            }
+        )
+
+    if not rows:
+        return
+
+    stmt = pg_insert(Sale).values(rows)
+    stmt = stmt.on_conflict_do_nothing(
+        index_elements=["property_id", "sale_date", "sale_price_cad", "source"]
+    )
+    await session.execute(stmt)
+
+
+# ---------------------------------------------------------------------------
+# Batch fetching from Properties
+# ---------------------------------------------------------------------------
+
+async def fetch_next_property_batch(session, offset: int, batch_size: int = BATCH_SIZE):
+    """
+    Fetch a batch of Properties to seed REW Insights for.
+
+    Strategy:
+      - province == 'BC'
+      - have street_address & city
+      - no existing PropertyCharacteristics from 'rew_insights'
+        (to avoid rework on properties we've already seeded)
+    """
+    pc_exists = exists().where(
+        and_(
+            PropertyCharacteristics.property_id == Property.id,
+            PropertyCharacteristics.source == "rew_insights",
+        )
+    )
+
+    stmt = (
+        select(Property)
+        .where(
+            Property.province == "BC",
+            Property.street_address.isnot(None),
+            Property.city.isnot(None),
+            ~pc_exists,
+        )
+        .order_by(Property.id)
+        .offset(offset)
+        .limit(batch_size)
+    )
+
+    result = await session.execute(stmt)
+    return result.scalars().all()
+
+
+# ---------------------------------------------------------------------------
+# Per-property processing
+# ---------------------------------------------------------------------------
+
+async def process_single_property(session, prop: Property):
+    """
+    For a given Property:
+      - Build a formatted address string
+      - Use REW Insights autocomplete HTTP endpoint to find the Insights URL
+      - Fetch that Insights page (requests)
+      - Parse it and upsert into PropertyCharacteristics, Assessment, Sale
+      - Optionally enqueue neighbour URLs
+    """
+
+    full_addr = format_full_address(
+        prop.street_address,
+        prop.city,
+        prop.province,
+        prop.postal_code,
+    )
+
+    logger.info(f"[Property {prop.id}] Lookup REW Insights for address: {full_addr!r}")
+
+    try:
+        insights_url = lookup_insights_url_via_autocomplete(full_addr)
+    except Exception as e:
+        logger.exception(
+            f"[Property {prop.id}] Autocomplete lookup failed: {e}"
+        )
+        return
+
+    if not insights_url:
+        logger.info(
+            f"[Property {prop.id}] No Insights URL found via autocomplete for {full_addr!r}"
+        )
+        return
+
+    logger.info(f"[Property {prop.id}] Insights URL: {insights_url}")
+
+    try:
+        resp = requests.get(
+            insights_url,
+            headers={"User-Agent": "Mozilla/5.0 (rew-insights-seeder)"},
+            timeout=30,
+        )
+        resp.raise_for_status()
+    except Exception as e:
+        logger.exception(
+            f"[Property {prop.id}] Failed to fetch Insights page {insights_url}: {e}"
+        )
+        return
+
+    html = resp.text
+
+    parsed = parse_rew_insights(html, insights_url)
+    basic = parsed.get("basic") or {}
+
+    # If the page gives a better canonical address, we COULD reconcile here.
+    # For seeding, we just attach data to the existing Property row.
+    property_id = prop.id
+
+    # Characteristics snapshot
+    await upsert_property_characteristics_rew_insights(session, property_id, basic)
+
+    # Assessments
+    assessments = parsed.get("assessments") or []
+    await upsert_assessments_rew_insights(session, property_id, assessments)
+
+    # Sales history
+    sales = parsed.get("sales") or []
+    await upsert_sales_rew_insights(session, property_id, sales)
+
+    # Neighbourhood links -> optional fan-out
+    links = parsed.get("neighbourhood_links") or {}
+    insights_urls = links.get("insights_urls") or []
+    listing_urls = links.get("listing_urls") or []
+
+    if insights_urls:
+        inserted_insights = await enqueue_insights_urls(insights_urls, session)
+        logger.info(
+            f"[Property {prop.id}] Enqueued {inserted_insights} neighbouring REW Insights URLs"
+        )
+    
+    if listing_urls:
+        inserted_listings = await enqueue_urls(listing_urls, session)
+        logger.info(
+            f"[Property {prop.id}] Enqueued {inserted_listings} neighbouring REW listing URLs"
+        )
+
+    await session.commit()
+    logger.info(
+        f"[Property {prop.id}] Seeded REW Insights data "
+        f"for property_id={property_id} ({full_addr})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main loop
+# ---------------------------------------------------------------------------
+
+async def main():
+    await init_db()
+    logger.info("DB init complete for REW Insights seeder")
+
+    offset = 0
+
+    while True:
+        async with AsyncSessionLocal() as session:
+            logger.info(
+                f"Fetching Properties batch: offset={offset}, size={BATCH_SIZE}"
+            )
+            props = await fetch_next_property_batch(
+                session, offset=offset, batch_size=BATCH_SIZE
+            )
+
+            if not props:
+                logger.info(
+                    f"No more Properties needing REW Insights. "
+                    f"Sleeping {EMPTY_SLEEP_SECONDS} seconds..."
+                )
+                await asyncio.sleep(EMPTY_SLEEP_SECONDS)
+                # For a pure "one-off" seeder, you might prefer to break instead:
+                # break
+                continue
+
+            for prop in props:
+                try:
+                    await process_single_property(session, prop)
+                except Exception as e:
+                    logger.exception(
+                        f"Error processing Property {prop.id}: {e}"
+                    )
+
+                sleep_for = PER_PROPERTY_SLEEP_SECONDS + random.uniform(0, 1)
+                logger.info(
+                    f"Sleeping {sleep_for:.2f}s before next property..."
+                )
+                await asyncio.sleep(sleep_for)
+
+            offset += len(props)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -20,6 +20,7 @@ from models import (
     Base,
     RewListing,
     RewListingUrl,
+    RewInsightsUrl,
     Sale,
     Assessment,
     Property,
@@ -79,7 +80,6 @@ def _pick_primary_source(source: str, preferred: List[str]) -> int:
     except ValueError:
         return len(preferred)
 
-
 def merge_assessments(assessments: List[Assessment]) -> List[Dict[str, Any]]:
     """
     Merge assessments by (property_id, assessment_year), preferring
@@ -118,7 +118,6 @@ def merge_assessments(assessments: List[Assessment]) -> List[Dict[str, Any]]:
         previous = row
 
     return merged_rows
-
 
 def merge_sales(sales: List[Sale]) -> List[Dict[str, Any]]:
     """
@@ -161,7 +160,6 @@ def merge_sales(sales: List[Sale]) -> List[Dict[str, Any]]:
 
     merged_rows.sort(key=lambda r: r["sale_date"], reverse=True)
     return merged_rows
-
 
 def merge_property_characteristics(chars: List[PropertyCharacteristics]) -> List[Dict[str, Any]]:
     """
@@ -228,7 +226,6 @@ def group_assessments_by_source(assessments: List[Assessment]) -> Dict[str, List
 
     return dict(by_source)
 
-
 def group_sales_by_source(sales: List[Sale]) -> Dict[str, List[Sale]]:
     """
     Return {source: [Sale, ...]} sorted by date desc.
@@ -241,7 +238,6 @@ def group_sales_by_source(sales: List[Sale]) -> Dict[str, List[Sale]]:
         rows.sort(key=lambda s: s.sale_date, reverse=True)
 
     return dict(by_source)
-
 
 def group_characteristics_by_source(chars: List[PropertyCharacteristics]) -> Dict[str, List[PropertyCharacteristics]]:
     """
@@ -265,7 +261,6 @@ async def on_startup():
     # Ensure tables exist (idempotent)
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
-
 
 @app.get("/", response_class=HTMLResponse)
 async def home(request: Request):
@@ -353,6 +348,83 @@ async def home(request: Request):
         latest_rew_done = (
             await session.execute(latest_rew_done_stmt)
         ).scalars().first()
+
+        # --- REW Insights scraper panel ------------------------------------
+        total_rew_insights_urls_stmt = select(func.count(RewInsightsUrl.id))
+        total_rew_insights_urls = (
+            await session.execute(total_rew_insights_urls_stmt)
+        ).scalar() or 0
+
+        rew_insights_done_urls_stmt = select(func.count(RewInsightsUrl.id)).where(
+            RewInsightsUrl.status == "done"
+        )
+        rew_insights_done_urls = (
+            await session.execute(rew_insights_done_urls_stmt)
+        ).scalar() or 0
+
+        rew_insights_error_urls_stmt = select(func.count(RewInsightsUrl.id)).where(
+            RewInsightsUrl.status == "error"
+        )
+        rew_insights_error_urls = (
+            await session.execute(rew_insights_error_urls_stmt)
+        ).scalar() or 0
+
+        rew_insights_dead_urls_stmt = select(func.count(RewInsightsUrl.id)).where(
+            RewInsightsUrl.status == "dead"
+        )
+        rew_insights_dead_urls = (
+            await session.execute(rew_insights_dead_urls_stmt)
+        ).scalar() or 0
+
+        rew_insights_pending_urls = (
+            total_rew_insights_urls
+            - rew_insights_done_urls
+            - rew_insights_error_urls
+            - rew_insights_dead_urls
+        )
+
+        rew_insights_scrape_ratio = (
+            rew_insights_done_urls / total_rew_insights_urls
+            if total_rew_insights_urls > 0
+            else 0.0
+        )
+
+        # Latest discovered
+        latest_rew_insights_discovered_stmt = (
+            select(RewInsightsUrl)
+            .order_by(RewInsightsUrl.discovered_at.desc())
+            .limit(1)
+        )
+        latest_rew_insights_discovered = (
+            await session.execute(latest_rew_insights_discovered_stmt)
+        ).scalars().first()
+
+        # Latest successfully scraped
+        latest_rew_insights_done_stmt = (
+            select(RewInsightsUrl)
+            .where(RewInsightsUrl.status == "done")
+            .order_by(RewInsightsUrl.last_attempt_at.desc().nullslast())
+            .limit(1)
+        )
+        latest_rew_insights_done = (
+            await session.execute(latest_rew_insights_done_stmt)
+        ).scalars().first()
+
+        # Latest REW Insights properties (property characteristics)
+        latest_rew_insights_props_stmt = (
+            select(PropertyCharacteristics, Property)
+            .join(Property, Property.id == PropertyCharacteristics.property_id)
+            .where(PropertyCharacteristics.source == "rew_insights")
+            .order_by(
+                PropertyCharacteristics.scraped_at.desc().nullslast(),
+                PropertyCharacteristics.id.desc(),
+            )
+            .limit(10)
+        )
+
+        latest_rew_insights_props = (
+            await session.execute(latest_rew_insights_props_stmt)
+        ).all()
 
         # --- BC Assessment scraper panel ------------------------------------
         total_bca_urls_stmt = select(func.count(BCAssessmentUrl.id))
@@ -472,6 +544,16 @@ async def home(request: Request):
             "scrape_ratio": rew_scrape_ratio,
             "latest_discovered": latest_rew_discovered,
             "latest_done": latest_rew_done,
+            # REW Insights scraper stats
+            "total_rew_insights_urls": total_rew_insights_urls,
+            "rew_insights_done_urls": rew_insights_done_urls,
+            "rew_insights_pending_urls": rew_insights_pending_urls,
+            "rew_insights_error_urls": rew_insights_error_urls,
+            "rew_insights_dead_urls": rew_insights_dead_urls,
+            "rew_insights_scrape_ratio": rew_insights_scrape_ratio,
+            "latest_rew_insights_discovered": latest_rew_insights_discovered,
+            "latest_rew_insights_done": latest_rew_insights_done,
+            "latest_rew_insights_props": latest_rew_insights_props,
             # BC Assessment scraper stats
             "bca_done_urls": bca_done_urls,
             "bca_pending_urls": bca_pending_urls,
@@ -483,7 +565,6 @@ async def home(request: Request):
             "latest_bca_props": latest_bca_props,
         },
     )
-
 
 @app.get("/listings", response_class=HTMLResponse)
 async def listings(request: Request, page: int = 1, page_size: int = 20):
@@ -559,7 +640,6 @@ async def listing_detail(request: Request, listing_id: int):
             "raw_sales_by_source": raw_sales_by_source
         },
     )
-
 
 @app.get("/properties/search", name="properties_search", response_class=HTMLResponse)
 async def properties_search(
@@ -826,7 +906,6 @@ async def properties_search(
         },
     )
 
-
 @app.get("/properties/{property_id}", response_class=HTMLResponse)
 async def property_detail(request: Request, property_id: int):
     async with AsyncSessionLocal() as session:
@@ -894,7 +973,6 @@ async def property_detail(request: Request, property_id: int):
             "current_char": current_char,
         }
     )
-
 
 @app.get("/map", response_class=HTMLResponse)
 async def map_view( 

--- a/webapp/models.py
+++ b/webapp/models.py
@@ -38,6 +38,25 @@ class RewListingUrl(Base):
     attempts = Column(Integer, nullable=False, server_default="0")
     last_error = Column(Text)
 
+class RewInsightsUrl(Base):
+    """
+    Queue of REW Insights URLs to crawl.
+
+    We store fully qualified URLs like:
+      https://www.rew.ca/insights/12345
+    plus metadata for worker retries.
+    """
+    __tablename__ = "rew_insights_urls"
+
+    id = Column(Integer, primary_key=True)
+    url = Column(Text, unique=True, nullable=False)
+
+    discovered_at = Column(DateTime(timezone=True), server_default=func.now())
+    status = Column(Text, nullable=False, server_default="pending")
+    last_attempt_at = Column(DateTime(timezone=True))
+    attempts = Column(Integer, nullable=False, server_default="0")
+    last_error = Column(Text)
+
 class BCAssessmentUrl(Base):
     """
     Queue of BC Assessment property pages to crawl.

--- a/webapp/templates/home.html
+++ b/webapp/templates/home.html
@@ -146,6 +146,88 @@
 
     </section>
 
+    <!-- REW Insights Scraper Panel -->
+    <section class="panel">
+      <div class="panel-header">
+        <h2>REW Insights Scraper</h2>
+      </div>
+
+      <div class="stats-list">
+        <span>Total Insights URLs discovered: <strong>{{ total_rew_insights_urls }}</strong></span>
+        <span>Done: <strong>{{ rew_insights_done_urls }}</strong></span>
+        <span>Pending: <strong>{{ rew_insights_pending_urls }}</strong></span>
+        <span>Error: <strong>{{ rew_insights_error_urls }}</strong></span>
+        <span>Dead: <strong>{{ rew_insights_dead_urls }}</strong></span>
+        <span>Scraped ratio:
+          <strong>
+            {% if rew_insights_scrape_ratio %}
+              {{ "%.1f" % (rew_insights_scrape_ratio * 100) }}%
+            {% else %}
+              0.0%
+            {% endif %}
+          </strong>
+        </span>
+      </div>
+
+      <p class="muted">
+        Latest discovered REW Insights URL:
+        {% if latest_rew_insights_discovered %}
+          <code>{{ latest_rew_insights_discovered.url }}</code>
+        {% else %}
+          None yet
+        {% endif %}
+        <br>
+        Latest successfully scraped REW Insights URL:
+        {% if latest_rew_insights_done %}
+          <code>{{ latest_rew_insights_done.url }}</code>
+        {% else %}
+          None yet
+        {% endif %}
+      </p>
+
+      <h3>Latest REW Insights properties</h3>
+      <table>
+        <tr>
+          <th>Scraped At</th>
+          <th>Address</th>
+          <th>Beds</th>
+          <th>Baths</th>
+          <th>Building Sqft</th>
+          <th>Lot Sqft</th>
+          <th>Year Built</th>
+          <th>As of Date</th>
+        </tr>
+        {% for char, prop in latest_rew_insights_props %}
+        <tr>
+          <td>{{ char.scraped_at }}</td>
+          <td>
+            {% if prop %}
+              <a href="{{ request.url_for('property_detail', property_id=prop.id) }}">
+                {{ prop.street_address }}, {{ prop.city }}
+              </a>
+            {% else %}
+              (no linked property)
+            {% endif %}
+          </td>
+          <td>{{ char.beds }}</td>
+          <td>{{ char.baths }}</td>
+          <td>
+            {% if char.sqft_finished %}
+              {{ char.sqft_finished }}
+            {% elif char.sqft_unfinished %}
+              {{ char.sqft_unfinished }}
+            {% else %}
+              – 
+            {% endif %}
+          </td>
+          <td>{{ char.lot_sqft }}</td>
+          <td>{{ char.year_built }}</td>
+          <td>{{ char.as_of_date }}</td>
+        </tr>
+        {% endfor %}
+      </table>
+    </section>
+
     <!-- BC Assessment Scraper Panel -->
     <section class="panel">
       <div class="panel-header">


### PR DESCRIPTION
Creates a Rew Insights scraper that queries the Rew Insights, which contain details about off-market properties. It also contains lat/lng data as well as a map polygon bbox for the property. 

With the worker comes updates to the models, a new table for tracking RewInsightsUrl objects, and a seed script to look up addresses from the properties table to start the fanning process.

This service is much more reliable than BC Assessments and provides a lot more data, especially sales and geocoding data.